### PR TITLE
Pandoc URI can be overriden via system property.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ check.dependsOn integrationTest
 gradleTest {
     versions '3.5', '4.0.2', '4.6'
     dependsOn cacheTestProductBinaries
-    musrRunAfter integrationTest
+    mustRunAfter integrationTest
     systemProperties 'io.doctoolchain.gradle.pandoc.uri': productTestCacheDir.absoluteFile.toURI()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,18 @@ plugins {
     id 'groovy'
     id 'org.ysb33r.gradletest' version '2.0-alpha-6'
     id 'com.gradle.plugin-publish' version '0.9.7'
+    id 'fi.linuxbox.download.worker' version '0.3'
 }
+
+import fi.linuxbox.gradle.download.worker.DownloadWorkerTask
+
+version = '0.1-SNAPSHOT'
+group = 'io.doctoolchain.gradle'
 
 ext {
     spockGroovyVer = GroovySystem.version.replaceAll(/\.\d+$/,'') 
+
+    notSnapshot = { !version.endsWith('-SNAPSHOT') }
 }
 
 repositories {
@@ -46,6 +54,8 @@ sourceSets {
     }
 }
 
+apply from : 'gradle/cache-downloads.gradle'
+
 task integrationTest(type: Test, dependsOn: jar) {
 
     description 'Runs the integration tests'
@@ -54,17 +64,36 @@ task integrationTest(type: Test, dependsOn: jar) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     reports.html.destination = file("${reporting.baseDir}/integrationTests")
+    systemProperties 'io.doctoolchain.gradle.pandoc.uri': productTestCacheDir.absoluteFile.toURI()
 
+    dependsOn cacheTestProductBinaries
     mustRunAfter test
-
-    enabled = !gradle.startParameter.offline
 }
 
 check.dependsOn integrationTest
 
 
 gradleTest {
-    versions '3.5'
+    versions '3.5', '4.0.2', '4.6'
+    dependsOn cacheTestProductBinaries
+    musrRunAfter integrationTest
+    systemProperties 'io.doctoolchain.gradle.pandoc.uri': productTestCacheDir.absoluteFile.toURI()
+}
+
+
+productTestVersions.each { ver ->
+
+    final String relativePath = "${ver}/pandoc-${ver}-${productOsArch}"
+    final File target = file("${productTestCacheDir}/${relativePath}")
+
+    Task downloader = tasks.create("downloadPandoc${ver}", DownloadWorkerTask) {
+        from "https://github.com/jgm/pandoc/releases/download/${relativePath}"
+        to target
+
+        onlyIf { !target.exists() }
+    }
+
+    cacheTestProductBinaries.dependsOn downloader
 }
 
 
@@ -82,3 +111,9 @@ pluginBundle {
         }
     }
 }
+
+publishPlugins {
+    mustRunAfter build
+    onlyIf notSnapshot
+}
+

--- a/gradle/cache-downloads.gradle
+++ b/gradle/cache-downloads.gradle
@@ -1,0 +1,46 @@
+ext {
+
+    codedProductVersion = (file('src/main/groovy/io/doctoolchain/gradle/pandoc/PandocExtension.groovy').readLines().grep {
+        it =~ /static\s+final\s+String\s+DEFAULT_PANDOC_VERSION\s+=/
+    })[0].replaceFirst(~/^(.+?["'])/, '').replaceFirst(~/(["'].*)$/, '')
+
+    currentOS = org.gradle.internal.os.OperatingSystem.current()
+    productTestCacheDir = file("${buildDir}/pandoc-binaries")
+
+    // Always list the primary test version as the first one in this list.
+    productTestVersions = [codedProductVersion, '2.2']
+
+    productOsArch = { ->
+        def productOS
+        def productExt = 'zip'
+
+        if (currentOS.windows) {
+            productAbi = '-msvc'
+            if (System.getProperty('os.arch').contains('64')) {
+                productOS = 'windows-x86_64'
+            } else {
+                productOS = 'windows-i386'
+            }
+        } else if (currentOS.linux) {
+            productOS = 'linux'
+            productExt = 'tar.gz'
+        } else if (currentOS.macOsX) {
+            productOS = 'macOS'
+        }
+
+        "${productOS}.${productExt}".toString()
+    }.call()
+
+    pandocConfigurationNameFor = { ver ->
+        "pandoc.${ver}"
+    }
+}
+
+task cacheTestProductBinaries {
+    group 'Infrastructure'
+    description 'Download pandoc binaries for test purposes'
+    enabled = !project.gradle.startParameter.offline
+}
+
+
+

--- a/src/main/groovy/io/doctoolchain/gradle/pandoc/Downloader.groovy
+++ b/src/main/groovy/io/doctoolchain/gradle/pandoc/Downloader.groovy
@@ -12,7 +12,8 @@ import org.ysb33r.grolifant.api.AbstractDistributionInstaller
 @CompileStatic
 class Downloader extends AbstractDistributionInstaller {
 
-    final static OperatingSystem os = OperatingSystem.current()
+    final static OperatingSystem OS = OperatingSystem.current()
+    final static String baseURI = System.getProperty('io.doctoolchain.gradle.pandoc.uri') ?: 'https://github.com/jgm/pandoc/releases/download'
 
     Downloader(String version, Project project) {
         super("pandoc", version, "binary/pandoc", project)
@@ -20,22 +21,18 @@ class Downloader extends AbstractDistributionInstaller {
 
     @Override
     URI uriFromVersion(String version) {
-        return "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-${osArchitecture()}".toURI()
+        "${baseURI}/$version/pandoc-$version-${osArchitecture()}".toURI()
     }
 
     String osArchitecture() {
-        if (os.isWindows()) {
-            return "windows-x86_64.zip"
+        if (OS.isWindows()) {
+            System.getProperty('os.arch').contains('64') ? 'windows-x86_64.zip' : 'windows-i386.zip'
+        } else if (OS.isLinux()) {
+            "linux.tar.gz"
+        } else if (OS.isMacOsX()) {
+            "macOS.zip"
+        } else {
+            throw new GradleException("${OS} does not support downloading of pandoc")
         }
-
-        if (os.isLinux()){
-            return "linux.tar.gz"
-        }
-
-        if (os.isMacOsX()) {
-            return "macOS.zip"
-        }
-
-        throw new GradleException("Unssuported OS")
     }
 }

--- a/src/main/groovy/io/doctoolchain/gradle/pandoc/PandocExtension.groovy
+++ b/src/main/groovy/io/doctoolchain/gradle/pandoc/PandocExtension.groovy
@@ -9,8 +9,10 @@ import org.gradle.api.Project
 @CompileStatic
 class PandocExtension {
 
+    // This line is also read by the build - be care ful if you modify it's layout
+    static final String DEFAULT_PANDOC_VERSION = '2.2.1'
 
-    String version = '2.2.1'
+    String version = DEFAULT_PANDOC_VERSION
 
     PandocExtension(Project project1) {
         this.project = project1
@@ -19,7 +21,7 @@ class PandocExtension {
     File getPandocExecutable() {
         Downloader downloader = new Downloader(getVersion(),this.project)
 
-        new File(downloader.distributionRoot,Downloader.os.isWindows() ? 'pandoc.exe' : 'bin/pandoc')
+        new File(downloader.distributionRoot,Downloader.OS.isWindows() ? 'pandoc.exe' : 'bin/pandoc')
     }
 
     private final Project project


### PR DESCRIPTION
- Override default download URI via system property.
  This is mainly meant for testing, but can be useful in some contexts.
- Download pandoc binaries for testing purposes so that every test does
  not need to go online.
- Added version & group so that published plugin will be a good citizen.
- Only allow the plugin to be published is the vesion is not a snapshot.
- Compatibility testing against Gradle 3.5, 4.0.2, 4.6.